### PR TITLE
Bug in wrap memory

### DIFF
--- a/overlays/test_wrap_memory.py
+++ b/overlays/test_wrap_memory.py
@@ -311,3 +311,47 @@ def test_save_edited_file() -> None:
     assert class_grandparents_env.get("b.Z", "", use_saved_contents_of_dependents=False) == ["a.X"]
     assert class_grandparents_env.get("b.W", "", use_saved_contents_of_dependents=True) == []
     assert class_grandparents_env.get("b.W", "", use_saved_contents_of_dependents=False) == []
+
+
+
+def test_edge_case() -> None:
+    def set_up():
+        (
+            code_env,
+            ast_env,
+            class_body_env,
+            class_parents_env,
+            class_grandparents_env
+        ) = create_env_stack(code={
+            "a": """
+                class X: pass
+                class Y(a.X): pass
+            """,
+            "b": """
+                class B0(a.X): pass
+                class B1(a.Y): pass
+            """,
+        })
+
+        # create some dependencies; this isn't actually important, it's just needed
+        # because the code isn't very robust
+        class_grandparents_env.get("b.B0", "", use_saved_contents_of_dependents=True)
+
+        # Trigger a pair of updates
+        class_grandparents_env.update("a", code="""
+            class X: pass
+            class Y: pass
+        """, is_saved_content=False)
+
+        return class_grandparents_env
+
+    class_grandparents_env = set_up()
+    # If the saved key always exists first we are okay, a saved module will use saved
+    # dependencies.
+    assert class_grandparents_env.get("b.B1", "", use_saved_contents_of_dependents=True) == ["a.X"]
+    assert class_grandparents_env.get("b.B1", "", use_saved_contents_of_dependents=False) == ["a.X"]
+
+    class_grandparents_env = set_up()
+    # But we can contaminate a saved module if we look up a new key in unsaved mode
+    assert class_grandparents_env.get("b.B1", "", use_saved_contents_of_dependents=False) == []
+    assert class_grandparents_env.get("b.B1", "", use_saved_contents_of_dependents=True) == []

--- a/overlays/test_wrap_memory.py
+++ b/overlays/test_wrap_memory.py
@@ -314,7 +314,7 @@ def test_save_edited_file() -> None:
 
 
 
-def test_edge_case() -> None:
+def test_edge_case__now_fixed() -> None:
     def set_up():
         (
             code_env,
@@ -346,12 +346,11 @@ def test_edge_case() -> None:
         return class_grandparents_env
 
     class_grandparents_env = set_up()
-    # If the saved key always exists first we are okay, a saved module will use saved
-    # dependencies.
+    # we get the same results...
     assert class_grandparents_env.get("b.B1", "", use_saved_contents_of_dependents=True) == ["a.X"]
     assert class_grandparents_env.get("b.B1", "", use_saved_contents_of_dependents=False) == ["a.X"]
 
     class_grandparents_env = set_up()
-    # But we can contaminate a saved module if we look up a new key in unsaved mode
-    assert class_grandparents_env.get("b.B1", "", use_saved_contents_of_dependents=False) == []
-    assert class_grandparents_env.get("b.B1", "", use_saved_contents_of_dependents=True) == []
+    # ... regardless of the order in which we call `get`
+    assert class_grandparents_env.get("b.B1", "", use_saved_contents_of_dependents=False) == ["a.X"]
+    assert class_grandparents_env.get("b.B1", "", use_saved_contents_of_dependents=True) == ["a.X"]

--- a/overlays/wrap_memory.py
+++ b/overlays/wrap_memory.py
@@ -55,16 +55,23 @@ class EnvTable(Generic[T]):
 
     def get(self, key: str, dependency: str, use_saved_contents_of_dependents: bool) -> T:
         self.register_dependency(key, dependency)
-
-        target_cache_table = (self.writable_env.saved_contents_cache_table
-                              if use_saved_contents_of_dependents or module(key) not in self.writable_env.unsaved_modules
-                              else self.writable_env.unsaved_contents_cache_table)
+        use_saved_contents = (
+            use_saved_contents_of_dependents or
+            module(key) not in self.writable_env.unsaved_modules
+        )
+        target_cache_table = (
+            self.writable_env.saved_contents_cache_table
+            if use_saved_contents
+            else self.writable_env.unsaved_contents_cache_table
+        )
         # Update the saved_contents_cache_table whether the module is
         # saved or unsaved.
         if key not in target_cache_table:
             target_cache_table[key] = self.produce_value(
                 key,
-                self.upstream_get(use_saved_contents_of_dependents),
+                self.upstream_get(
+                    use_saved_contents_of_dependents=use_saved_contents
+                ),
                 current_env_getter=target_cache_table.get
             )
 


### PR DESCRIPTION
It is extremely tricky to get the right behavior when using only global memory and relying on if conditions to always propagate information about whether we are in an overlay.

In this PR I have
- first a commit illustrating a bug, where if we ask for information about a saved file from
   an unsaved file and there's no precomputed cache, we get the wrong data
- next, a fix for the bug: if at any point in a chain of `get` requests we realize we're not in an
   overlay, we should turn off the unsaved mode henceforth

My view is even if we use this memory layout, it would be better to wrap the environments but that may be difficult.

An alternative approach is to use shared memory tables that we make first-class - we could potentially do this using first-class modules but Jia and I are leaning toward instead using an extended key that includes an overlay id.